### PR TITLE
chore: Update publish docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,9 @@ This will create db.sql file (a Sqlite database) with a table `Names` and two re
 
 ## Building and publishing the plugin
 
-Use the following command to build a container with the plugin:
+1. Update the plugin metadata in [src/plugins.ts](src/plugin.ts#L99) to match your team and plugin name.
+2. Run `npm run build` to build the plugin.
+3. Run `node dist/main.js package -m "Initial release" v0.0.1 .`. `-m` specifies changelog and `v0.0.1` is the version.
+4. Run `cloudquery plugin publish -f` to publish the plugin to the CloudQuery registry.
 
-```shell
-npm run package:container
-```
-
-Check out the [Releasing and Deploying Your Plugin
-](https://www.cloudquery.io/docs/developers/creating-new-plugin/javascript-source#releasing-and-deploying-your-plugin) in our documentation to learn more about publishing your own plugin for wider use.
+> More about publishing plugins [here](https://docs.cloudquery.io/docs/developers/publishing-an-addon-to-the-hub)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# JavaScript Source Plugin Template
+
+This is the plugin documentation that will get published to Hub. Read more about publishing at [CloudQuery Docs](https://docs.cloudquery.io/docs/developers/publishing-a-plugin-to-the-hub)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "scripts": {
     "dev": "ts-node --esm src/main.ts serve",
     "build": "rm -rf dist && tsc",
-    "package:container": "docker build -t cq-js-sample:latest .",
     "format": "prettier --write 'src/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts'",
     "lint": "eslint --max-warnings 0 --ext .ts src",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -85,12 +85,12 @@ export const newSamplePlugin = () => {
     spec,
     { noConnection },
   ) => {
-    pluginClient.spec = parseSpec(spec);
-    pluginClient.client = { id: () => "cq-js-sample" };
     if (noConnection) {
       pluginClient.allTables = [];
       return pluginClient;
     }
+    pluginClient.spec = parseSpec(spec);
+    pluginClient.client = { id: () => "cq-js-sample" };
     pluginClient.allTables = await getTables();
 
     return pluginClient;

--- a/sync-packaged.yml
+++ b/sync-packaged.yml
@@ -2,10 +2,8 @@ kind: source
 spec:
   name: "cq-js-sample"
   registry: "docker"
-  path: "cq-js-sample:latest"
-  version: "v1.0.0"
-  tables:
-    ["*"]
+  path: "docker.cloudquery.io/cloudquery/source-cq-js-sample:v0.0.1-linux-arm64"
+  tables: ["*"]
   destinations:
     - "sqlite"
   spec: {}


### PR DESCRIPTION
Similar to https://github.com/cloudquery/python-plugin-template/pull/5 updates the template to better explain how to publish the docker image to the CloudQuery registry