### PR TITLE
chore(ci): Replace GH_CQ_BOT PAT with GitHub App tokens

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,7 +1,7 @@
 version = 1
 
 [approve]
-auto_approve_usernames = ["cq-bot"]
+auto_approve_usernames = ["cloudquery-ci"]
 
 [merge.message]
 body = "pull_request_body"


### PR DESCRIPTION
Replace GH_CQ_BOT PAT with short-lived tokens from the cloudquery-ci GitHub App.