### PR TITLE
chore: Add blockExoticSubdeps to pnpm config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+block-exotic-subdeps=true


### PR DESCRIPTION
Add `block-exotic-subdeps=true` to `.npmrc` to prevent subdependencies from using exotic specifiers (git URLs, HTTP URLs, etc.), reducing supply chain attack surface.